### PR TITLE
added ptp sync

### DIFF
--- a/ouster_client/src/os1.cpp
+++ b/ouster_client/src/os1.cpp
@@ -142,6 +142,8 @@ std::shared_ptr<client> init_client(const std::string& hostname,
     success &= do_cmd("set_udp_port_lidar", std::to_string(lidar_port));
     success &= do_cmd("set_udp_port_imu", std::to_string(imu_port));
     success &= do_cmd("set_udp_ip", udp_dest_host);
+    success &= do_cmd("set_timestamp_mode", "TIME_FROM_PTP_1588");
+    success &= do_cmd("reinitialize", "");
 
     if (!success) return std::shared_ptr<client>();
 


### PR DESCRIPTION
Adds in setting to use ptp timesync on startup and rejects measurements until the sync happens.

To use ptp install with
`sudo apt install linuxptp`

edit the parameters for starting the service
`sudo vim /lib/systemd/system/ptp4l.service`

all you need to set is
`ExecStart=/usr/sbin/ptp4l -i <your ethernet interface>`
in my case `ExecStart=/usr/sbin/ptp4l -i enp0s25`

then start the service
`service ptp4l start`

and make it run on boot
`sudo systemctl enable ptp4l`